### PR TITLE
enhance: figure out which browser to use

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,6 @@ export async function getBrowser (): Promise<string> {
 }
 
 export async function getNewContext (browser: string, sessionDir: string, javaScriptEnabled: boolean): Promise<BrowserContext> {
-  console.log(`Launching ${browser}...`)
   switch (browser) {
     case 'chrome':
       return await chromium.launchPersistentContext(

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,25 @@
 import { type BrowserContext, chromium, firefox } from '@playwright/test'
 
+export async function getBrowser (): Promise<string> {
+  const browsers = [
+    { name: 'Chrome', launchFunction: async () => await chromium.launch({ channel: 'chrome' }) },
+    { name: 'Edge', launchFunction: async () => await chromium.launch({ channel: 'msedge' }) },
+    { name: 'Firefox', launchFunction: async () => await firefox.launch() }
+  ]
+
+  for (const browser of browsers) {
+    try {
+      const browserInstance = await browser.launchFunction()
+      void browserInstance.close()
+      return browser.name.toLowerCase()
+    } catch (error) {}
+  }
+
+  throw new Error('No supported browsers (Chrome, Edge, Firefox) are installed.')
+}
+
 export async function getNewContext (browser: string, sessionDir: string, javaScriptEnabled: boolean): Promise<BrowserContext> {
+  console.log(`Launching ${browser}...`)
   switch (browser) {
     case 'chrome':
       return await chromium.launchPersistentContext(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,8 @@
 import path from 'node:path'
 import { search } from './search.ts'
 import { genQuery } from './genQuery.ts'
-import { getNewContext } from './context.ts'
+import { getBrowser, getNewContext } from './context.ts'
 import * as gptscript from '@gptscript-ai/gptscript'
-
-const VALID_BROWSERS = ['chrome', 'firefox', 'edge']
 
 const gptsClient = new gptscript.GPTScript()
 
@@ -28,12 +26,7 @@ if (process.env.GPTSCRIPT_WORKSPACE_ID === undefined || process.env.GPTSCRIPT_WO
 }
 const sessionDir = path.resolve(process.env.GPTSCRIPT_WORKSPACE_DIR) + '/browser_session'
 
-const browserName = (process.env.GPTSCRIPT_INSTALLED_BROWSER ?? 'chrome').toLowerCase()
-if (!VALID_BROWSERS.includes(browserName)) {
-  console.log('error: invalid browser name', browserName)
-  console.log('valid browsers:', VALID_BROWSERS.join(', '))
-  process.exit(1)
-}
+const browserName = await getBrowser()
 
 // Simultaneously start the browser and generate our search query.
 const queryPromise = genQuery(question)

--- a/tool.gpt
+++ b/tool.gpt
@@ -1,6 +1,5 @@
 name: answers-from-the-internet
 description: Uses Google to answer the provided question
-credential: github.com/gptscript-ai/credential as installedBrowser with "Which browser do you want to use? (Options: chrome, firefox, edge)" as message and "browser" as field and "GPTSCRIPT_INSTALLED_BROWSER" as env and false as sensitive
 args: question: the question to ask
 
 #!/usr/bin/env npm --prefix ${GPTSCRIPT_TOOL_DIR} run tool


### PR DESCRIPTION
Rather than asking the user (through the cred framework) to state which browser they would like to use, we just check for each one in the order of Chrome, then Edge, then Firefox, and use the first that we find. I didn't notice any impact to execution speed from doing this.

This also solves the problem of Firefox not working on Windows, since it should never get used, since Windows is never without Edge (except for extraordinary circumstances).

(Also now that this tool has reached a pretty good state, I'm gonna start doing PRs for future updates rather than just pushing to main on my own like I used to.)