### PR TITLE
Add missing dependencies when compiling ts code

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@gptscript-ai/gptscript": "0.8.1",
+    "@playwright/test": "^1.41.2",
     "@types/turndown": "^5.0.4",
     "async-mutex": "^0.5.0",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
We are missing a dependency and that is causing some typescript compiling error.

The error is reveal once we added more tsconfig option.

```
> tool
> node --no-warnings --loader ts-node/esm src/server.ts
{


node:internal/process/esm_loader:34
      internalBinding('errors').triggerUncaughtException(
                                ^
Error: Cannot find package '@playwright/test' imported from /Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/src/context.ts
    at packageResolve (/Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:757:9)
    at moduleResolve (/Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:798:18)
    at Object.defaultResolve (/Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:912:11)
    at /Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/src/esm.ts:218:35
    at entrypointFallback (/Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/src/esm.ts:168:34)
    at /Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/src/esm.ts:217:14
    at addShortCircuitFlag (/Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/src/esm.ts:409:21)
    at resolve (/Users/daishan/Library/Caches/gptscript/repos/401d974b425bbdd5637618c492beafbb644cad4c/tool.gpt/node21/node_modules/ts-node/src/esm.ts:197:12)
    at nextResolve (node:internal/modules/esm/hooks:750:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:238:30)
```

https://github.com/gptscript-ai/gptscript/issues/714