### PR TITLE
Putting playwright into dependencies instead of dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,11 @@
         "env-paths": "^3.0.0",
         "express": "^4.18.2",
         "global-cache-dir": "^6.0.0",
+        "playwright": "^1.46.0",
         "ts-node-dev": "^2.0.0",
         "turndown": "^7.1.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.41.2",
         "@types/body-parser": "^1.19.5",
         "@types/express": "^4.17.21",
         "@types/node": "^20.11.19",
@@ -257,12 +257,39 @@
       "version": "1.44.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
       "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
-      "dev": true,
       "dependencies": {
         "playwright": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "dependencies": {
+        "playwright-core": "1.44.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "bin": {
+        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=16"
@@ -3615,33 +3642,31 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
-      "dev": true,
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
+      "integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
       "dependencies": {
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.46.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
-      "dev": true,
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
+      "integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "tool": "node --no-warnings --loader ts-node/esm src/server.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.41.2",
     "@types/body-parser": "^1.19.5",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.19",
@@ -28,6 +27,7 @@
     "env-paths": "^3.0.0",
     "express": "^4.18.2",
     "global-cache-dir": "^6.0.0",
+    "playwright": "^1.46.0",
     "ts-node-dev": "^2.0.0",
     "turndown": "^7.1.3"
   }


### PR DESCRIPTION
Playwright libary is previously placed into dev dependencies and it won't be installed when NODE_ENV=production.

UI runs with NODE_ENV=production now and will cause this tool an error.