### PR TITLE
fix: enable parallel tool calls with random session dirs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3235,10 +3235,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,5 @@
 import { type BrowserContext, chromium, firefox } from '@playwright/test'
+import { randomInt } from 'node:crypto'
 
 export async function getBrowser (): Promise<string> {
   const browsers = [
@@ -22,10 +23,17 @@ export async function getBrowser (): Promise<string> {
   throw new Error(`No supported browsers (Chrome, Edge, Firefox) are installed. ${errors}`)
 }
 
-export async function getNewContext (browser: string, sessionDir: string, javaScriptEnabled: boolean): Promise<BrowserContext> {
+export interface ContextAndSessionDir {
+  context: BrowserContext
+  sessionDir: string
+}
+
+export async function getNewContext (browser: string, workspaceDir: string, javaScriptEnabled: boolean): Promise<ContextAndSessionDir> {
+  const sessionDir = workspaceDir + '/afti_browser_session_' + randomInt(1, 1000000).toString()
+  let context: BrowserContext
   switch (browser) {
     case 'chromium':
-      return await chromium.launchPersistentContext(
+      context = await chromium.launchPersistentContext(
         sessionDir,
         {
           userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
@@ -35,8 +43,9 @@ export async function getNewContext (browser: string, sessionDir: string, javaSc
           ignoreDefaultArgs: ['--enable-automation', '--use-mock-keychain'],
           javaScriptEnabled
         })
+      break
     case 'chrome':
-      return await chromium.launchPersistentContext(
+      context = await chromium.launchPersistentContext(
         sessionDir,
         {
           userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
@@ -47,8 +56,9 @@ export async function getNewContext (browser: string, sessionDir: string, javaSc
           ignoreDefaultArgs: ['--enable-automation', '--use-mock-keychain'],
           javaScriptEnabled
         })
+      break
     case 'firefox':
-      return await firefox.launchPersistentContext(
+      context = await firefox.launchPersistentContext(
         sessionDir,
         {
           userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Firefox/89.0 Safari/537.36',
@@ -56,8 +66,9 @@ export async function getNewContext (browser: string, sessionDir: string, javaSc
           viewport: null,
           javaScriptEnabled
         })
+      break
     case 'edge':
-      return await chromium.launchPersistentContext(
+      context = await chromium.launchPersistentContext(
         sessionDir,
         {
           userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.64',
@@ -68,7 +79,10 @@ export async function getNewContext (browser: string, sessionDir: string, javaSc
           ignoreDefaultArgs: ['--enable-automation', '--use-mock-keychain'],
           javaScriptEnabled
         })
+      break
     default:
       throw new Error(`Unknown browser: ${browser}`)
   }
+
+  return { context, sessionDir }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,8 +28,6 @@ const [query, context, noJSContext] = await Promise.all([queryPromise, contextPr
 
 // Query Google
 const pageContents = await search(browserName, context.context, noJSContext.context, query)
-await context.context.close()
-await noJSContext.context.close()
 
 // Ask gpt-4o to generate an answer
 const tool: gptscript.ToolDef = {
@@ -90,6 +88,8 @@ run.on(gptscript.RunEventType.CallProgress, data => {
   process.stdout.write(data.output[0].content.slice(prev.length))
   prev = data.output[0].content
 })
+await context.context.close()
+await noJSContext.context.close()
 rmSync(context.sessionDir, { recursive: true, force: true })
 rmSync(noJSContext.sessionDir, { recursive: true, force: true })
 await run.text()

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,9 +88,13 @@ run.on(gptscript.RunEventType.CallProgress, data => {
   process.stdout.write(data.output[0].content.slice(prev.length))
   prev = data.output[0].content
 })
+
+// While we wait for GPTScript to execute, we want to remove the session dirs we used.
+// Each session dir is usually at least 20MB, and they are one-time use, so we don't need to keep them around.
 await context.context.close()
 await noJSContext.context.close()
 rmSync(context.sessionDir, { recursive: true, force: true })
 rmSync(noJSContext.sessionDir, { recursive: true, force: true })
+
 await run.text()
 process.exit(0)

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,8 +7,6 @@ import { rmSync } from 'node:fs'
 
 const gptsClient = new gptscript.GPTScript()
 
-delete process.env.GPTSCRIPT_INPUT
-
 const question: string = process.env.QUESTION ?? ''
 if (question === '') {
   console.log('error: no question provided')


### PR DESCRIPTION
for https://github.com/gptscript-ai/gptscript/issues/842

This fixes parallel calls to this tool by using a random session directory rather than a predetermined one. That way, we can run an arbitrarily high number of browser sessions at once, if the LLM calls this tool in parallel.