### PR TITLE
chore: run npm tool silently

### DIFF
--- a/tool.gpt
+++ b/tool.gpt
@@ -3,4 +3,4 @@ share context: github.com/gptscript-ai/credentials/model-provider
 description: Uses Google to answer the provided question
 args: question: the question to ask
 
-#!/usr/bin/env npm --prefix ${GPTSCRIPT_TOOL_DIR} run tool
+#!/usr/bin/env npm --prefix ${GPTSCRIPT_TOOL_DIR} run tool --silent


### PR DESCRIPTION
This will prevent the annoying and unnecessary printing of the script name (`tool`) and command to stdout when it runs, and instead only print the actual output from the tool, which is what we want.